### PR TITLE
Fix assertresume bug

### DIFF
--- a/libs/coroutine.lua
+++ b/libs/coroutine.lua
@@ -25,7 +25,7 @@ function ext_coro.assertresume(thread, ...)
 		error(traceback(thread, err), 0)
 	end
 
-	return unpack(args)
+	return err, unpack(args)
 end
 
 ---Returns whether or not the function was run inside of a coroutine. Returns false if it is on the main thread.


### PR DESCRIPTION
This should fix the bug where assertresume would discard the first return from the thread.