### PR TITLE
Fixing various minor bugs and cleanup

### DIFF
--- a/libs/coroutine.lua
+++ b/libs/coroutine.lua
@@ -1,11 +1,12 @@
 ---Extensions to the Lua standard coroutine library.
 ---@module extensions.coroutine
 ---@alias ext_coro
+local pack = table.pack
 local resume, running = coroutine.resume, coroutine.running
 local traceback = debug.traceback
 
 local function pack_vararg(success, err, ...)
-	return success, err, {...}
+	return success, err, pack(...)
 end
 
 local ext_coro = {}
@@ -14,7 +15,7 @@ for k, v in pairs(coroutine) do
 	ext_coro[k] = v
 end
 
----Properly asserts a coroutine resume in order to get the correct traceback on error. Consumes the first two returns from resume (success and err)
+---Properly asserts a coroutine resume in order to get the correct traceback on error. Consumes the first return from resume (the success boolean)
 ---and returns the rest.
 ---@param thread thread
 ---@param[opt] ... any
@@ -25,7 +26,7 @@ function ext_coro.assertresume(thread, ...)
 		error(traceback(thread, err), 0)
 	end
 
-	return err, unpack(args)
+	return err, unpack(args, 1, args.n)
 end
 
 ---Returns whether or not the function was run inside of a coroutine. Returns false if it is on the main thread.

--- a/libs/table.lua
+++ b/libs/table.lua
@@ -259,7 +259,7 @@ end
 ---@param tbl table
 ---@return boolean
 function ext_table.isempty(tbl)
-	return not next(tbl)
+	return (next(tbl)) == nil
 end
 
 ---Shuffles a table in place.
@@ -267,7 +267,7 @@ end
 ---@return table
 function ext_table.shuffle(tbl)
 	for i = #tbl, 1, -1 do
-		local j = math.random(i)
+		local j = random(i)
 		tbl[i], tbl[j] = tbl[j], tbl[i]
 	end
 
@@ -287,7 +287,7 @@ end
 ---@return any, any
 function ext_table.randomvalue(tbl)
 	local values = ext_table.values(tbl)
-	return values[math.random(#values)]
+	return values[random(#values)]
 end
 
 ---Returns a random key, value index from a table.


### PR DESCRIPTION
1. Fix `table.isempty` returning `true` if `false` is a key
2. Fix `coroutine.assertresume` not unpacking args correctly sometimes
3. Update `coroutine.assertresume` docs
4. `math.random` vs `random` consistency