### PR TITLE
math: fix root method

### DIFF
--- a/libs/math.lua
+++ b/libs/math.lua
@@ -47,16 +47,18 @@ function ext_math.cbrt(n)
 	return n ^ (1 / 3)
 end
 
----Returns the `base`th root of `n`.
+---Returns the `n`th root of `x`.
 ---@param n number
 ---@param base number
 ---@return number
-function ext_math.root(n, base)
-	if base < 1 or n % 2 == 0 and n < 0 then
+function ext_math.root(x, n)
+    if n == 0 then
+        return 1
+    elseif x < 0 then
 		return ext_math.nan
 	end
 
-	return n ^ (1 / base)
+	return x ^ (1 / n)
 end
 
 ---Returns true if `n` is nan.

--- a/libs/math.lua
+++ b/libs/math.lua
@@ -48,8 +48,8 @@ function ext_math.cbrt(n)
 end
 
 ---Returns the `n`th root of `x`.
+---@param x number
 ---@param n number
----@param base number
 ---@return number
 function ext_math.root(x, n)
     if n == 0 then


### PR DESCRIPTION
While writing unit tests for the package, I noticed a couple of things:

- `root(n, 0)` where `n` is any number; returns NaN, when it should always be returning `1`.

- `root(4, -2)` returns NaN, when it should return `0.5` (and so on).

- also change argument names and description to well reflect "nth root of x number", instead of "baseth root of n number" (which may confuse some). 
