### PR TITLE
use math.root for the cbrt implementation

### DIFF
--- a/libs/math.lua
+++ b/libs/math.lua
@@ -60,7 +60,7 @@ end
 ---@param n number
 ---@return number
 function ext_math.cbrt(n)
-	return n ^ (1 / 3)
+	return ext_math.root(n, 3)
 end
 
 ---Returns the real `base`th root of `n`. This extends the root function to


### PR DESCRIPTION
Makes `math.cbrt` an equivalent for `math.root(n, 3)`.   This helps with inputs such as `cbrt(-27)` extending into negative range.