### PR TITLE
base: fix enumerateall not reusing the state

### DIFF
--- a/libs/base.lua
+++ b/libs/base.lua
@@ -64,8 +64,9 @@ function ext_base.enumerateall(iterator, ...)
     local tbl = {}
 
     local last = { ... }
+    local state = table.remove(last, 1)
     while true do
-        local ret = { iterator(unpack(last)) }
+        local ret = { iterator(state, unpack(last)) }
         if ret[1] == nil then
             break
         end


### PR DESCRIPTION
In Lua, the generic for loop has a signature of `for x, y, etc in iterator, state, initial_key do`, where `state` is consistantly reused.

As it is now, `base.enumerateall(pairs{1, 2})` will error on the second iteration, because the table (the state) is not being repassed to `next`, but rather it becomes `iterator(1)`.
