### PR TITLE
editorconfig: use tabs instead of spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ insert_final_newline = true
 end_of_line = lf
 charset = utf-8
 
-indent_style = space
+indent_style = tab
 indent_size = 4


### PR DESCRIPTION
Seems like in commit #657a670 project is suppose to use tabs.  Although in .configeditor, it is set to use spaces instead of tabs.

Or is it supposed to be the opposite?