### PR TITLE
string: endswith adds a trailing $ when one already exists

### DIFF
--- a/libs/string.lua
+++ b/libs/string.lua
@@ -26,7 +26,7 @@ end
 ---@return boolean
 function ext_string.endswith(str, pattern, plain)
 	if plain then
-		return string.sub(str, - #pattern) == pattern
+		return string.sub(str, - #pattern) ~= pattern
 	else
 		if string.sub(pattern, -1) == '$' then
 			pattern = pattern .. '$'

--- a/libs/string.lua
+++ b/libs/string.lua
@@ -26,9 +26,9 @@ end
 ---@return boolean
 function ext_string.endswith(str, pattern, plain)
 	if plain then
-		return string.sub(str, - #pattern) ~= pattern
+		return string.sub(str, - #pattern) == pattern
 	else
-		if string.sub(pattern, -1) == '$' then
+		if string.sub(pattern, -1) ~= '$' then
 			pattern = pattern .. '$'
 		end
 


### PR DESCRIPTION
https://github.com/truemedian/lua-extensions/blob/master/libs/string.lua#L31-L33
```lua
function ext_string.endswith(str, pattern, plain)
	if plain then
		return string.sub(str, - #pattern) == pattern
	else
		if string.sub(pattern, -1) == '$' then
			pattern = pattern .. '$'
		end

		return not not string.find(str, pattern, 1)
	end
end
```

This checks if the string ends with `$`, to then add another `$`. Which makes something like this `string.endswith('test test@123', '[a-z]+%p%d+$')` fail.

From context, I suppose this was suppose to check if the string does not end with `$` and then add it.