### PR TITLE
string: better PUC Lua compatiblity

### DIFF
--- a/libs/string.lua
+++ b/libs/string.lua
@@ -68,7 +68,7 @@ end
 ---@return string
 function ext_string.rjust(str, final_len, pattern)
 	pattern = pattern or ' '
-	return string.rep(pattern, (final_len - #str) / #pattern) .. str
+	return string.rep(pattern, math.floor((final_len - #str) / #pattern)) .. str
 end
 
 ---Returns a new string with both sides padded with `pattern` or spaces until
@@ -95,7 +95,7 @@ end
 ---@return string
 function ext_string.ljust(str, final_len, pattern)
 	pattern = pattern or ' '
-	return str .. string.rep(pattern, (final_len - #str) / #pattern)
+	return str .. string.rep(pattern, math.floor((final_len - #str) / #pattern))
 end
 
 ---Returns a table of all elements of the string split on `delim`. Use `plain`


### PR DESCRIPTION
Given the following code:
```lua
string.rep("foo", 2.5)
```

In LuaJIT and Lua 5.1, this would still work as expected, it seems to floor the input resulting in `foofoo`.  In 5.2 and above it seems to error with `bad argument #2 to 'rep' (number has no integer representation)`.

This can happen to rjust and ljust when either given a multi-byte pattern with `final_len` that does not align up, or when given `final_len` that is not an integer.
For example `string.rjust("test", 9, "123")`.

To make sure the behavior is overall the same in Luvit and PUC Lua I thought adding this math.floor made sense.

Note: one more place where the behavior differs across implementation is when `final_len` is `1/0`, in Luajit that would return an empty string, in Lua >= 5.2 it would raise a similar error.  But this is a pretty unlikely edge case that we shouldn't do much about.