### PR TITLE
string.split invalid return on empty string delimiter

### DIFF
--- a/libs/string.lua
+++ b/libs/string.lua
@@ -113,7 +113,7 @@ function ext_string.split(str, delim, plain)
 
 	if not delim or delim == '' then
 		for i = 1, #str do
-			ret[i] = string.char(string.byte(str, i))
+			ret[i] = string.sub(str, i, i)
 		end
 
 		return ret

--- a/libs/string.lua
+++ b/libs/string.lua
@@ -113,7 +113,7 @@ function ext_string.split(str, delim, plain)
 
 	if not delim or delim == '' then
 		for i = 1, #str do
-			ret[i] = string.byte(str, i)
+			ret[i] = string.char(string.byte(str, i))
 		end
 
 		return ret


### PR DESCRIPTION
```lua
string.split("hello", "")
```

Currently returns `{ 104, 101, 108, 108, 111 }`, since this is a fairly strange thing to return I assume it is not the intended behavior.  Which means it is likely this was supposed to be `string.char(string.byte())` instead of just `string.byte`.

Also: why not use `string.sub(str, i, i)` instead?
