### PR TITLE
standardize behavior on math.random(0)

### DIFF
--- a/libs/table.lua
+++ b/libs/table.lua
@@ -313,7 +313,7 @@ function ext_table.shuffle(tbl)
 	return tbl
 end
 
----Returns a random key and the value associated with it from an array, or `nil` on an empty array.
+---Returns a random (key, value) pair selected from the sequence portion of a table, or `nil` on an empty array.
 ---
 ---This function only works on the sequence portion of the table. Its behavior is undefined if the table has holes.
 ---@param tbl table
@@ -326,7 +326,7 @@ function ext_table.randomipair(tbl)
 	return i, tbl[i]
 end
 
----Returns a random key and the value associated with it from an array, or `nil` on an empty array.
+---Returns a random value selected from a table, or `nil` on an empty table.
 ---@param tbl table
 ---@return any|nil, any|nil
 function ext_table.randomvalue(tbl)
@@ -337,7 +337,7 @@ function ext_table.randomvalue(tbl)
 	return values[math.random(#values)]
 end
 
----Returns a random key and the value associated with it from a table, or `nil` on an empty table.
+---Returns a random (key, value) pair selected from a table, or `nil` on an empty table.
 ---@param tbl table
 ---@return any|nil, any|nil
 function ext_table.randompair(tbl)

--- a/libs/table.lua
+++ b/libs/table.lua
@@ -241,7 +241,7 @@ end
 ---at.
 ---@param tbl table
 ---@param value any
----@return any|nil
+---@return any
 function ext_table.search(tbl, value)
 	for k, v in pairs(tbl) do
 		if v == value then
@@ -328,7 +328,7 @@ end
 
 ---Returns a random value selected from a table, or `nil` on an empty table.
 ---@param tbl table
----@return any|nil, any|nil
+---@return any, any
 function ext_table.randomvalue(tbl)
 	local values = ext_table.values(tbl)
 	if #values == 0 then
@@ -339,7 +339,7 @@ end
 
 ---Returns a random (key, value) pair selected from a table, or `nil` on an empty table.
 ---@param tbl table
----@return any|nil, any|nil
+---@return any, any
 function ext_table.randompair(tbl)
 	local count = ext_table.count(tbl)
 	if count == 0 then

--- a/libs/table.lua
+++ b/libs/table.lua
@@ -317,7 +317,7 @@ end
 ---
 ---This function only works on the sequence portion of the table. Its behavior is undefined if the table has holes.
 ---@param tbl table
----@return any|nil, any|nil
+---@return any, any
 function ext_table.randomipair(tbl)
 	if #tbl == 0 then
 		return

--- a/libs/table.lua
+++ b/libs/table.lua
@@ -313,29 +313,39 @@ function ext_table.shuffle(tbl)
 	return tbl
 end
 
----Returns a random key, value index from an array.
+---Returns a random key and the value associated with it from an array, or `nil` on an empty array.
 ---
 ---This function only works on the sequence portion of the table. Its behavior is undefined if the table has holes.
 ---@param tbl table
----@return any, any
+---@return any|nil, any|nil
 function ext_table.randomipair(tbl)
+	if #tbl == 0 then
+		return
+	end
 	local i = math.random(#tbl)
 	return i, tbl[i]
 end
 
----Returns a random key, value index from an array.
+---Returns a random key and the value associated with it from an array, or `nil` on an empty array.
 ---@param tbl table
----@return any, any
+---@return any|nil, any|nil
 function ext_table.randomvalue(tbl)
 	local values = ext_table.values(tbl)
+	if #values == 0 then
+		return
+	end
 	return values[math.random(#values)]
 end
 
----Returns a random key, value index from a table.
+---Returns a random key and the value associated with it from a table, or `nil` on an empty table.
 ---@param tbl table
----@return any, any
+---@return any|nil, any|nil
 function ext_table.randompair(tbl)
-	local rand = math.random(ext_table.count(tbl))
+	local count = ext_table.count(tbl)
+	if count == 0 then
+		return
+	end
+	local rand = math.random(count)
 	local n = 0
 	for k, v in pairs(tbl) do
 		n = n + 1


### PR DESCRIPTION
In LuaJIT, math.random(0) would return 1, on Lua 5.4 it would return an integer with all the random bits, on 5.3 and below it would error. This makes the behavior on empty tables relating table.randompair and the alike the same no matter the version.

The behavior I chose here is to simply return nil if the table/array is empty.

Also reworded the description a bit, in my opinion it reads better like this.